### PR TITLE
Preserve file permission when installing using composer project

### DIFF
--- a/tasks/build-composer-project.yml
+++ b/tasks/build-composer-project.yml
@@ -27,7 +27,7 @@
 
 - name: Move Drupal project files to drupal_composer_install_dir (this may take a while).
   command: >
-    cp -r /tmp/composer-project/. {{ drupal_composer_install_dir }}/
+    cp -pr /tmp/composer-project/. {{ drupal_composer_install_dir }}/
     creates={{ drupal_core_path }}/index.php
   become: false
   when: not drupal_site_exists


### PR DESCRIPTION
(This is a repost of geerlingguy/drupal-vm#1817 as requested by geerlingguy.)

Composer project ensures that the [files directory](https://github.com/drupal-composer/drupal-project/blob/8.x/scripts/composer/ScriptHandler.php#L55) (and maybe the sync directory when [my PR](https://github.com/drupal-composer/drupal-project/pull/415) gets approved) has correct permission. However, the build-composer-project task uses `cp -r` which doesn't preserve permission. Since umask is 022 it kills the writable bits. The easy fix is to add -p to the cp command.

PS! Windows users that uses the default vagrant_synced_folders setting doesn't experience this problem as the sync forces writable files and directories on Linux - probably because the different permission model on Linux and Windows. It took me a while to understand what was going on when I disabled syncing (to get better performance) and Drupal suddenly lost all styling ...